### PR TITLE
Adjusting bad Discord OAuth Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Schedule dates to play games with your friends. 🙂
 - _optional_: [just](https://github.com/casey/just?tab=readme-ov-file#installation)
 
 When using mise you can to install the pinned versions of the software in `mise.toml`
+
 ```shell
 mise install
 ```

--- a/migrations/20250619010518_discord_oauth.sql
+++ b/migrations/20250619010518_discord_oauth.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE player ADD COLUMN session_id VARCHAR(128) NOT NULL;
+ALTER TABLE player ADD COLUMN session_id VARCHAR(128);
 ALTER TABLE player ADD COLUMN oauth_token VARCHAR(128);
 -- +goose StatementEnd
 


### PR DESCRIPTION
We can't require session id to not be null unless we set all existing users session ids to some value. Instead of that lets remove this constraint and revisit later.

This migration was ran in production manually too so if this isn't satisfactory we will need to "roll forward".